### PR TITLE
Fix - Script fails under Windows 10

### DIFF
--- a/mbedignore.py
+++ b/mbedignore.py
@@ -1,7 +1,6 @@
 from os import path
 import os.path
 import sys
-from pathlib import Path
 from shutil import copyfile
 
 Import("env")
@@ -27,7 +26,7 @@ def _is_ignored(path):
     contains a line with string '*'.
     """
     mbedignore_path = os.path.join(path, '.mbedignore')
-    if not Path(mbedignore_path).is_file():
+    if not os.path.isfile(mbedignore_path):
         return False
     with open(mbedignore_path) as f:
         lines = f.read().splitlines()
@@ -41,7 +40,7 @@ def _is_extra_newline_necessary(file):
     a line to it. Sometimes there is no newline at the end of the file
     so this function checks that.
     """
-    if not Path(file).is_file() or os.path.getsize(file) == 0:
+    if not os.path.isfile(file) or os.path.getsize(file) == 0:
         return False
     with open(file, 'rb+') as f:
         f.seek(-1, os.SEEK_END)
@@ -68,7 +67,7 @@ def _lines_to_set(path):
     which are lines in the file. Returns empty set when file doesn't exist.
     """
     out = set()
-    if Path(path).is_file():
+    if os.path.isfile(path):
         with open(path) as f:
             out = set(f.read().splitlines())
     return out
@@ -96,7 +95,7 @@ def _make_unignored(path):
     lines = _lines_to_list(mbedignore_path)
     lines.remove('*')
     if len(lines) == 0:
-        Path(mbedignore_path).unlink()
+        os.unlink(mbedignore_path)
     else:
         with open(mbedignore_path, 'w') as f:
             for line in lines:
@@ -158,10 +157,10 @@ def apply(mbedignore_path, framework_path):
 
     """
     # Perform sanitization
-    if not Path(mbedignore_path).is_file():
+    if not os.path.isfile(mbedignore_path):
         _eprint("\nERROR: Input .mbedignore is not a file.")
         _print_usage_and_exit()
-    if not Path(framework_path).is_dir():
+    if not os.path.isdir(framework_path):
         _eprint(
             "\nERROR: The specified path to the mbed-os framework "
             "is not a directory.")


### PR DESCRIPTION
Under Windows 10 the script would fail with an error similar to: `'OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'C:\\Users\\Chris\\.platformio\\packages\\framework-mbed\\features\\frameworks\\utest\\*\\.mbedignore'`

<details>
<summary>Click here for the full error</summary>

```
MBED_OS_DIR: C:\Users\Chris\.platformio\packages\framework-mbed
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'C:\\Users\\Chris\\.platformio\\packages\\framework-mbed\\features\\frameworks\\utest\\*\\.mbedignore':
  File "C:\Users\Chris\.platformio\penv\Lib\site-packages\platformio\builder\main.py", line 175:
    env.SConscript(item, exports="env")
  File "C:\Users\Chris\.platformio\packages\tool-scons\scons-local-4.1.0\SCons\Script\SConscript.py", line 591:
    return _SConscript(self.fs, *files, **subst_kw)
  File "C:\Users\Chris\.platformio\packages\tool-scons\scons-local-4.1.0\SCons\Script\SConscript.py", line 280:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "C:\Projects\Mbed\Mbed Test Again\mbedignore.py", line 200:
    apply(mbedignore_path, mbed_os_dir)
  File "C:\Projects\Mbed\Mbed Test Again\mbedignore.py", line 182:
    _unignore_paths(framework_path, rel_paths_to_unignore)
  File "C:\Projects\Mbed\Mbed Test Again\mbedignore.py", line 121:
    if _is_ignored(path_to_unignore):
  File "C:\Projects\Mbed\Mbed Test Again\mbedignore.py", line 30:
    if not Path(mbedignore_path).is_file():
  File "C:\Program Files\Python39\lib\pathlib.py", line 1439:
    return S_ISREG(self.stat().st_mode)
  File "C:\Program Files\Python39\lib\pathlib.py", line 1221:
    return self._accessor.stat(self)
```
</details>

After running a debugger over the code, it appears that (in this case) the Path library does not operate the same way on Linux as it does on Windows. (This is a guess.)

This fix removes all calls to the Path library and replaces them with the equivalent `os.path` functions. For example, `Path(mbedignore_path).is_file()` becomes `os.path.isfile(mbedignore_path)`.

I'm submitting the PR to @Copper-Bot 's fork since that is the code I worked on after reading [this post](https://community.platformio.org/t/platformio-builds-mbed-sources-twice-while-debugging/18483/7). Plus I liked the examples. 😃  @KKoovalsky might be interested in the fix, too.
